### PR TITLE
Use `new` over `connect`

### DIFF
--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -83,10 +83,10 @@ module WebsocketRails
           # while sidekiq requires hiredis driver to work with
           if ENV['POD_TYPE'] == 'background' || Sidekiq.server?
             # hiredis
-            fiber_redis = Redis.connect(WebsocketRails.config.redis_options.merge(driver: :hiredis))
+            fiber_redis = Redis.new(WebsocketRails.config.redis_options.merge(driver: :hiredis))
           else
             # synchrony
-            fiber_redis = Redis.connect(WebsocketRails.config.redis_options)
+            fiber_redis = Redis.new(WebsocketRails.config.redis_options)
           end
 
           @server_token = generate_server_token


### PR DESCRIPTION
`connect` is deprecated and will be removed in future versions.
`connect` just aliases `new` today, so this is compatible with current
versions of the application today

https://github.com/redis/redis-rb/blob/v3.3.5/lib/redis.rb#L12-L15

NOTE: this is a hard requirement for Rails 5, and preferably one to complete without having to do weird things to the gemfiles in the meantime.