### PR TITLE
CL-27081, require redis file before to fix undefined deprecated! method error

### DIFF
--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -1,5 +1,5 @@
-require "redis/connection/synchrony"
 require "redis"
+require "redis/connection/synchrony"
 require "redis/connection/ruby"
 
 module WebsocketRails


### PR DESCRIPTION
https://jira.dev.e2open.com/jira/browse/CL-27081

In order to upgrade `sidekiq`, we need to upgrade `redis` gem. This gem also references synchrony file of `redis` gem which has some changes. Because of the change, we were getting error as `undefined method deprecate! for Redis:Class`. As a result we have to make this change.